### PR TITLE
feat: add a conda profile and environment file

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ The final output from this pipeline includes Lima output files, demultiplexed BA
 
 ## Dependencies
 
-This pipeline requires installation of [Nextflow](https://www.nextflow.io/docs/latest/install.html) and a containerization platform such as [Docker](https://docs.docker.com/engine/install/).
+This pipeline requires installation of [Nextflow](https://www.nextflow.io/docs/latest/install.html).
+It also requires installation of either a containerization platform such as [Docker](https://docs.docker.com/engine/install/) or a package manager such as [conda/mamba](https://mamba.readthedocs.io/en/latest/installation/mamba-installation.html).
 
 ## Docker Containers
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ All docker containers used in this pipeline are publicly available.
 - *fastqc*: quay.io/biocontainers/fastqc:0.12.1--hdfd78af_0
 - *multiqc*: quay.io/biocontainers/multiqc:1.21--pyhdfd78af_0
 
+## Conda Environment
+
+The conda environment is defined in `environment-pipeline.yml` and will be built automatically if the pipeline is run with `-profile conda`.
+
 # How to run the pipeline:
 
 ## Required Parameters

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Several profiles are available and can be selected with the `-profile` option at
 
 - `apptainer`
 - `aws`
+- `conda`
 - `docker`
 - `singularity`
 
@@ -86,11 +87,27 @@ nextflow run \
 
 # Running Test Data
 
+## With Docker
+
 The pipeline can be run using included test data with:
 
 ```bash
 nextflow run \
     -profile docker \
+    main.nf \
+    -c nextflow.config \
+    --pool_sheet "${PWD}/tests/pool_sheet.csv" \
+    --output "${PWD}/test_output" \
+    -with-report \
+    -with-trace \
+    -resume
+```
+
+## With Conda
+
+```bash
+nextflow run \
+    -profile conda \
     main.nf \
     -c nextflow.config \
     --pool_sheet "${PWD}/tests/pool_sheet.csv" \

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -2,7 +2,6 @@ name: longplex-nf-dev
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - bioconda::nextflow=23.10.1
   - conda-forge::python=3.11.0

--- a/environment-pipeline.yml
+++ b/environment-pipeline.yml
@@ -6,7 +6,6 @@ dependencies:
   - bioconda::fastqc=0.12.1
   - bioconda::lima=2.7.1
   - bioconda::multiqc=1.21
-  - bioconda::nextflow=23.10.1
   - bioconda::picard=3.2.0
   - bioconda::samtools=1.19.2
   - conda-forge::python=3.11.0

--- a/environment-pipeline.yml
+++ b/environment-pipeline.yml
@@ -1,0 +1,16 @@
+name: longplex-nf
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::fastqc=0.12.1
+  #- bioconda::lima=2.7.1
+  - bioconda::multiqc=1.21
+  - bioconda::nextflow=23.10.1
+  - bioconda::picard=3.2.0
+  - bioconda::samtools=1.19.2
+  - conda-forge::python=3.11.0
+  - conda-forge::pip=22.3.1
+  - conda-forge::r-base=4.3.1
+  - pip:
+    - git+https://github.com/seqwell/longplexpy@0.1.0

--- a/environment-pipeline.yml
+++ b/environment-pipeline.yml
@@ -11,9 +11,10 @@ dependencies:
   - bioconda::samtools=1.19.2
   - conda-forge::python=3.11.0
   - conda-forge::pip=22.3.1
-  - conda-forge::r-base=4.3.1
+  - conda-forge::r-base=4.3.3
   - conda-forge::r-dplyr=1.1.4
   - conda-forge::r-purrr=1.0.2
+  - conda-forge::readr=2.1.5
 
   - pip:
     - git+https://github.com/seqwell/longplexpy@0.1.0

--- a/environment-pipeline.yml
+++ b/environment-pipeline.yml
@@ -15,6 +15,7 @@ dependencies:
   - conda-forge::r-dplyr=1.1.4
   - conda-forge::r-purrr=1.0.2
   - conda-forge::r-readr=2.1.5
+  - conda-forge::r-stringr=1.5.1
 
   - pip:
     - git+https://github.com/seqwell/longplexpy@0.1.0

--- a/environment-pipeline.yml
+++ b/environment-pipeline.yml
@@ -16,6 +16,7 @@ dependencies:
   - conda-forge::r-purrr=1.0.2
   - conda-forge::r-readr=2.1.5
   - conda-forge::r-stringr=1.5.1
+  - conda-forge::r-tidyr=1.3.1
 
   - pip:
     - git+https://github.com/seqwell/longplexpy@0.1.0

--- a/environment-pipeline.yml
+++ b/environment-pipeline.yml
@@ -14,7 +14,7 @@ dependencies:
   - conda-forge::r-base=4.3.3
   - conda-forge::r-dplyr=1.1.4
   - conda-forge::r-purrr=1.0.2
-  - conda-forge::readr=2.1.5
+  - conda-forge::r-readr=2.1.5
 
   - pip:
     - git+https://github.com/seqwell/longplexpy@0.1.0

--- a/environment-pipeline.yml
+++ b/environment-pipeline.yml
@@ -12,5 +12,8 @@ dependencies:
   - conda-forge::python=3.11.0
   - conda-forge::pip=22.3.1
   - conda-forge::r-base=4.3.1
+  - conda-forge::r-dplyr=1.1.4
+  - conda-forge::r-purrr=1.0.2
+
   - pip:
     - git+https://github.com/seqwell/longplexpy@0.1.0

--- a/environment-pipeline.yml
+++ b/environment-pipeline.yml
@@ -4,7 +4,7 @@ channels:
   - bioconda
 dependencies:
   - bioconda::fastqc=0.12.1
-  #- bioconda::lima=2.7.1
+  - bioconda::lima=2.7.1
   - bioconda::multiqc=1.21
   - bioconda::nextflow=23.10.1
   - bioconda::picard=3.2.0

--- a/nextflow.config
+++ b/nextflow.config
@@ -130,6 +130,11 @@ profiles {
         docker.enabled = true
     }
 
+    conda {
+        conda.enabled = true
+        process.conda = 'environment-pipeline.yml'
+    }
+
     singularity {
         singularity.enabled = true
     }


### PR DESCRIPTION
The example can be run with:

```bash
nextflow run \
    -profile conda \
    main.nf \
    -c nextflow.config \
    --pool_sheet "${PWD}/tests/pool_sheet.csv" \
    --output "${PWD}/test_output" \
    -with-report \
    -with-trace \
    -resume
```

Note, this must be done in a linux environment because Lima does not have any Mac build available.