### PR TITLE
Remove lima report from MultiQC output

### DIFF
--- a/environment-pipeline.yml
+++ b/environment-pipeline.yml
@@ -18,4 +18,4 @@ dependencies:
   - conda-forge::r-tidyr=1.3.1
 
   - pip:
-    - git+https://github.com/seqwell/longplexpy@0.2.1
+    - git+https://github.com/seqwell/longplexpy@0.2.2

--- a/main.nf
+++ b/main.nf
@@ -65,16 +65,14 @@ workflow {
         .map { _meta, stats -> stats }
         .collect()
 
-    // temp remove lima from the multiqc
-    // MULTIQC(
-    //    FASTQC.out.archive.collect().ifEmpty([]),
-    //    both_end_stats,
-    //    either_end_stats
-    // )
+    
+     MULTIQC(
+        FASTQC.out.archive.collect().ifEmpty([]),
+        both_end_stats,
+        either_end_stats
+     )
 
-      MULTIQC(
-        FASTQC.out.archive.collect().ifEmpty([])
-      )
+
 
     // Pipeline Cleanup ////////////////////////////////////////////////////////////////////////////
 

--- a/modules/multiqc.nf
+++ b/modules/multiqc.nf
@@ -2,8 +2,8 @@ process MULTIQC {
 
     input:
     path('fastqc/*')
-    //path('demux_i7_i5/*')
-    //path('demux_either_i7_i5/*')
+    path('demux_i7_i5/*')
+    path('demux_either_i7_i5/*')
 
     output:
     path('*multiqc_report.html')
@@ -17,6 +17,9 @@ process MULTIQC {
         --force \\
         --interactive \\
         --no-data-dir \\
-        --verbose
+        --verbose \\
+        --ignore demux_i7_i5/ \\
+        --ignore demux_either_i7_i5
+        
     """
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -108,7 +108,7 @@ process {
     withName: MULTIQC {
         memory = '8.0G'
         cpus = 4
-        container = 'seqwell/longplexpy:0.2.1'
+        container = 'seqwell/longplexpy:0.2.2-2-gd350815'
         publishDir = [
             path: "${params.output}/multiqc",
             pattern: '*.html',


### PR DESCRIPTION
## Changes
- Removed lima report generation from MultiQC configuration
- Updated workflow files to exclude lima module

## Reason
- Using MultiQC to add the lima report is hard coded in longplexpy. Due to the version bump of MultiQC, it can not be run without further changes to the longplexpy. It is OK to temp remove the lima report from MultiQC report

## Testing
- Verified pipeline runs successfully without lima report
- Confirmed MultiQC generates properly with remaining modules
- All other functionality remains intact